### PR TITLE
Add status endpoint

### DIFF
--- a/functional_tests/Makefile
+++ b/functional_tests/Makefile
@@ -1,5 +1,5 @@
 test: venv
-	./venv/bin/pytest .
+	./venv/bin/pytest -s .
 
 start:
 	AUTH_KEY=s3cr3t ../bin/batch-scheduler

--- a/handlers/api/api.go
+++ b/handlers/api/api.go
@@ -15,6 +15,7 @@ import (
 func MuxAPI(schd *scheduler.Scheduler, authKey string) http.HandlerFunc {
 	router := mux.NewRouter()
 	router.HandleFunc("/api/schedules/{owner}", wrapMyHandler(schd, HandleGetSchedules)).Methods(http.MethodGet)
+	router.HandleFunc("/api/schedule/{uuid}", wrapMyHandler(schd, HandleGetSchedule)).Methods(http.MethodGet)
 	router.HandleFunc("/api/schedules", wrapMyHandler(schd, HandleGetSchedules)).Methods(http.MethodGet)
 	router.HandleFunc("/api/schedules", wrapMyHandler(schd, HandlePostSchedules)).Methods(http.MethodPost)
 	router.HandleFunc("/api/schedules/{owner}", wrapMyHandler(schd, HandlePostSchedules)).Methods(http.MethodPost)

--- a/handlers/api/schedule.go
+++ b/handlers/api/schedule.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/factorysh/batch-scheduler/owner"
+	"github.com/factorysh/batch-scheduler/scheduler"
+	"github.com/factorysh/batch-scheduler/task"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// HandleGetSchedule will retreive a task, convert it into a resp and return the data
+func HandleGetSchedule(schd *scheduler.Scheduler, u *owner.Owner, _ http.ResponseWriter, r *http.Request) (interface{}, error) {
+	fmt.Println(u)
+
+	vars := mux.Vars(r)
+	rawID, ok := vars[task.UUID]
+	if !ok {
+		return nil, errors.New("No uuid in request")
+	}
+
+	id, err := uuid.Parse(rawID)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := schd.GetTask(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.ToTaskResp(), nil
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -98,6 +98,8 @@ func (s *Scheduler) Load() error {
 		switch status {
 		case _run.Running:
 			fresh = _status.Running
+			// exec task will consume ressources, attach a watcher to exesting task without relaunching the entire task
+			s.execTask(t)
 		case _run.Dead:
 			fresh = _status.Error
 		case _run.Exited:

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -285,6 +285,10 @@ func (s *Scheduler) next() *_task.Task {
 	return tasks[0]
 }
 
+func (s *Scheduler) GetTask(id uuid.UUID) (*_task.Task, error) {
+	return s.tasks.Get(id)
+}
+
 // Cancel a task
 func (s *Scheduler) Cancel(id uuid.UUID) error {
 	task, err := s.tasks.Get(id)

--- a/task/task.go
+++ b/task/task.go
@@ -19,6 +19,9 @@ var ActionsRegistry map[string]func() action.Action
 // RunRegistry register all Run implementation
 var RunRegistry map[string]func() _run.Run
 
+// UUID indentifier for tasks
+const UUID = "uuid"
+
 func init() {
 	if ActionsRegistry == nil {
 		ActionsRegistry = make(map[string]func() action.Action)
@@ -59,6 +62,44 @@ type Task struct {
 	Environments    map[string]string  `json:"environments,omitempty"`
 	resourceCancel  context.CancelFunc `json:"-"`
 	Run             _run.Run           `json:"run"`
+}
+
+// Resp represent a task that can be send directly on the wire
+type Resp struct {
+	Start           time.Time         `json:"start"`              // Start time
+	MaxWaitTime     time.Duration     `json:"max_wait_time"`      // Max wait time before starting Action
+	MaxExectionTime time.Duration     `json:"max_execution_time"` // Max execution time
+	CPU             int               `json:"cpu"`                // CPU quota
+	RAM             int               `json:"ram"`                // RAM quota
+	Id              uuid.UUID         `json:"id"`                 // Id
+	Status          status.Status     `json:"status"`             // Status
+	Mtime           time.Time         `json:"mtime"`              // Modified time
+	Owner           string            `json:"owner"`              // Owner
+	Retry           int               `json:"retry"`              // Number of retry before crash
+	Every           time.Duration     `json:"every"`              // Periodic execution. Exclusive with Cron
+	Cron            string            `json:"cron"`               // Cron definition. Exclusive with Every
+	Environments    map[string]string `json:"environments,omitempty"`
+}
+
+// ToTaskResp will Convert a Task to TaskResp
+func (t *Task) ToTaskResp() Resp {
+
+	return Resp{
+		Start:           t.Start,
+		MaxWaitTime:     t.MaxWaitTime,
+		MaxExectionTime: t.MaxExectionTime,
+		CPU:             t.CPU,
+		RAM:             t.RAM,
+		Id:              t.Id,
+		Status:          t.Status,
+		Mtime:           t.Mtime,
+		Owner:           t.Owner,
+		Retry:           t.Retry,
+		Every:           t.Every,
+		Cron:            t.Cron,
+		Environments:    t.Environments,
+	}
+
 }
 
 type Duration time.Duration


### PR DESCRIPTION
This PR adds :

- `/api/schedule/{uuid}` endpoint to get job status https://github.com/factorysh/batch-scheduler/pull/29/commits/0da0c3d5dc2430c9c2ad157980f998c592a5a838
- adds a method in scheduler to get status of a task by UUID https://github.com/factorysh/batch-scheduler/pull/29/commits/0da0c3d5dc2430c9c2ad157980f998c592a5a838
- adds a new struct to only expose partial task data to end user (with copy pasta oriented programming) https://github.com/factorysh/batch-scheduler/pull/29/commits/0da0c3d5dc2430c9c2ad157980f998c592a5a838
- fixes/ensure that on a restart, everything is plugged in correctly to get fresh status and updates from docker https://github.com/factorysh/batch-scheduler/pull/29/commits/4da5ff32a0e10be5bbb525453f069cbbf5f1b04d & https://github.com/factorysh/batch-scheduler/pull/29/commits/639d3b0c4aff967e9ac4066211a92320d7d17c01

and of course tests