### PR TITLE
Add proper volumes support

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -95,7 +95,7 @@ func (v Volume) checkVolumeRules() error {
 	return nil
 }
 
-// addPrefix needs to be indempotent, if ./volumes is present, to prepend it another time
+// addPrefix needs to be idempotent, if ./volumes is present, to prepend it another time
 func (v *Volume) addPrefix() {
 
 	if !strings.HasPrefix(v.hostPath, "./volumes") {

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -140,7 +140,7 @@ func (c *Compose) SanitizeVolumes() error {
 				return fmt.Errorf("Can't cast volumes data into an array %v", vols)
 			}
 
-			sanitized := make([]string, len(volumes))
+			sanitized := make([]interface{}, len(volumes))
 			for i, vol := range volumes {
 				volume, ok := vol.(string)
 				if !ok {

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -122,6 +122,11 @@ func (c *Compose) UnmarshalYAML(value *yaml.Node) error {
 		}
 	}
 
+	err := c.SanitizeVolumes()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/factorysh/batch-scheduler/config"
 	"github.com/factorysh/batch-scheduler/task"
 	"github.com/factorysh/batch-scheduler/task/action"
 	_run "github.com/factorysh/batch-scheduler/task/run"
@@ -143,25 +144,11 @@ func (c Compose) Validate() error {
 	if err != nil {
 		return err
 	}
-	tmpfile := os.Getenv("BATCH_TMP")
-	if tmpfile == "" {
-		tmpfile = "/tmp"
-	}
-	tmpdir, err := ioutil.TempDir(tmpfile, "")
-	if err != nil {
-		return err
-	}
-	err = os.MkdirAll(tmpdir, 0750)
-	if err != nil {
-		return err
-	}
-	file, err := os.OpenFile(path.Join(tmpdir, "validator"), os.O_CREATE|os.O_WRONLY, 0640)
+	file, err := ioutil.TempFile(path.Join(config.GetDataDir(), "validator"), "validate-")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(file.Name())
-	defer os.Remove(tmpdir)
-
 	err = yaml.NewEncoder(file).Encode(c)
 	if err != nil {
 		return err

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -122,11 +122,6 @@ func (c *Compose) UnmarshalYAML(value *yaml.Node) error {
 		}
 	}
 
-	err := c.SanitizeVolumes()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -289,10 +289,12 @@ func TestSanitizeVolumes(t *testing.T) {
 		assert.True(t, ok)
 		vols, has := service["volumes"]
 		assert.True(t, has)
-		volumes, ok := vols.([]string)
+		volumes, ok := vols.([]interface{})
 		assert.True(t, ok)
 		for _, vol := range volumes {
-			assert.True(t, strings.HasPrefix(vol, "./volumes/some/path/on/the/host"))
+			volume, ok := vol.(string)
+			assert.True(t, ok)
+			assert.True(t, strings.HasPrefix(volume, "./volumes/some/path/on/the/host"))
 		}
 	}
 }

--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/factorysh/batch-scheduler/config"
 	_task "github.com/factorysh/batch-scheduler/task"
 	_status "github.com/factorysh/batch-scheduler/task/status"
 	"github.com/stretchr/testify/assert"
@@ -118,6 +119,13 @@ services:
 `
 
 func TestValidate(t *testing.T) {
+	testDir := "/tmp/batch-scheduler-tests"
+	os.MkdirAll(testDir, 0655)
+	defer os.RemoveAll(testDir)
+	os.Setenv("DATA_DIR", testDir)
+	err := config.EnsureDataDirs()
+	assert.NoError(t, err)
+
 	tests := []struct {
 		input []byte
 		isOk  bool

--- a/config/config.go
+++ b/config/config.go
@@ -18,11 +18,11 @@ func GetDataDir() string {
 	return b
 }
 
-// EnsureDirs creates needed directories
-func EnsureDirs() error {
+// EnsureDataDirs creates needed directories for data
+func EnsureDataDirs() error {
 
 	b := GetDataDir()
-	subs := [2]string{"validator", "wd"}
+	subs := [3]string{"validator", "wd", "store"}
 
 	for _, sub := range subs {
 		err := os.MkdirAll(fmt.Sprintf("%s/%s", b, sub), 0755)

--- a/examples/compose/sitespeed-compose.yml
+++ b/examples/compose/sitespeed-compose.yml
@@ -6,6 +6,6 @@ services:
     image: "sitespeedio/sitespeed.io:latest"
     command: "https://bearstech.com"
     volumes:
-      - "../output:/sitespeed.io/sitespeed-result/"
+      - "./output:/sitespeed.io/sitespeed-result/"
 x-batch:
   max_execution_time: 5m

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"time"
 
 	"github.com/factorysh/batch-scheduler/config"
@@ -32,20 +33,16 @@ func New() *Server {
 		log.Fatal("Server can't start without an authentication key (`AUTH_KEY` env variable)")
 	}
 
-	err := config.EnsureDirs()
+	err := config.EnsureDataDirs()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// TODO: dynamic ressource parameters (env, file, whatever)
-	// FIXME where is my home?
-	// TODO: storage kind and path from env
-	// Plug bbolt with violence
-	store, err := store.NewBoltStore("/tmp/batch.store")
+	store, err := store.NewBoltStore(path.Join(config.GetDataDir(), "store", "batch.store"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	s.Scheduler = scheduler.New(scheduler.NewResources(2, 512*16), runner.New("/tmp"), store)
+	s.Scheduler = scheduler.New(scheduler.NewResources(2, 512*16), runner.New(path.Join(config.GetDataDir(), "wd")), store)
 
 	var ok bool
 	if s.Addr, ok = os.LookupEnv("LISTEN"); !ok {


### PR DESCRIPTION
This PR uses and reorganize how volumes and how batch-scheduler stores things.

- DATA_DIR env is used to specify root data dir used by batch-scheduler

Structure is : 

```
/tmp/batch-scheduler
├── store
│   └── batch.store
├── validator
└── wd
    ├── 4a50336d-f979-4d55-9059-7436c34af4ad
    │   └── docker-compose.yml
    ├── 9b50bd9d-5c12-48fd-8038-030bce426fdb
    │   └── docker-compose.yml
    ├── adb9b01d-b9bd-474f-9e49-7995ee1d6af8
    │   └── docker-compose.yml
    ├── bb1935bd-eda0-49e6-823a-4f499fc1d986
    │   └── docker-compose.yml
    ├── c8c9a448-c5b9-4427-a2a3-2dbaacac22d8
    │   └── docker-compose.yml
    └── f90665c6-fdb8-48bd-8a89-50bd73e77abe
        └── docker-compose.yml
```

where `store` is for the bbolt db, `validator` is used as a tmp directory to verify compose file and `wd` is working directory.

In `wd` each task as it's own space with : 

- docker-compose.yml
- .env
- volumes dir that contains the volumes task storage

- [X] Reorganize storage
- [X] Volumes validation and constraints check
- [x] Lazy volumes tree creation on task UP.